### PR TITLE
Refactor Questions/Answers to be string array instead of newline delim

### DIFF
--- a/api/src/checkins/checkins.spec.ts
+++ b/api/src/checkins/checkins.spec.ts
@@ -22,12 +22,12 @@ describe("CheckinController", () => {
     const standup = await standupRepository.save({
       name: "test-standup",
       channelId: "channelId",
-      questions: "questions",
+      questions: ["questions"],
       days: [],
     });
 
     const checkin = await checkinRepository.save({
-      answers: "answers",
+      answers: ["answers"],
       postMessageTs: "postMessageTs",
       userId: "user",
     });
@@ -65,7 +65,7 @@ describe("CheckinController", () => {
       await standupRepository.save({
         name: "test-standup",
         channelId: "channelId",
-        questions: "questions",
+        questions: ["questions"],
         days: [],
       });
 
@@ -106,7 +106,7 @@ describe("CheckinController", () => {
         .post("/standups/channelId/checkins")
         .set("Accept", "application/json")
         .send({
-          answers: "new-answers",
+          answers: ["new-answers"],
           postMessageTs: "post-message-ts",
           userId: "user",
         })
@@ -115,7 +115,7 @@ describe("CheckinController", () => {
           expect(body).toEqual({
             id: expect.stringMatching(uuid),
             createdDate: expect.stringMatching(date),
-            answers: "new-answers",
+            answers: ["new-answers"],
             postMessageTs: "post-message-ts",
             userId: "user",
             channelId: "channelId",
@@ -130,7 +130,7 @@ describe("CheckinController", () => {
 
       return request(app.getHttpServer())
         .patch(`/standups/channelId/checkins/${checkin.id}`)
-        .send({ answers: "new-answers" })
+        .send({ answers: ["new-answers"] })
         .expect(200);
     });
   });

--- a/api/src/checkins/dto/checkin.dto.ts
+++ b/api/src/checkins/dto/checkin.dto.ts
@@ -14,8 +14,8 @@ export class CheckinDto {
   createdDate: Date;
 
   @Expose()
-  @IsString()
-  answers: string;
+  @IsString({ each: true })
+  answers: string[];
 
   @Expose()
   @IsString()

--- a/api/src/checkins/dto/create-checkin.dto.ts
+++ b/api/src/checkins/dto/create-checkin.dto.ts
@@ -1,8 +1,8 @@
 import { IsNotEmpty, IsString } from "class-validator";
 
 export class CreateCheckinDto {
-  @IsString()
-  answers: string;
+  @IsString({ each: true })
+  answers: string[];
 
   @IsString()
   postMessageTs: string;

--- a/api/src/checkins/dto/update-checkin.dto.ts
+++ b/api/src/checkins/dto/update-checkin.dto.ts
@@ -1,9 +1,9 @@
 import { IsNotEmpty, IsString } from "class-validator";
 
 export class UpdateCheckinDto {
-  @IsString()
+  @IsString({ each: true })
   @IsNotEmpty()
-  answers: string;
+  answers: string[];
 
   @IsString()
   @IsNotEmpty()

--- a/api/src/checkins/entities/checkin.entity.ts
+++ b/api/src/checkins/entities/checkin.entity.ts
@@ -16,8 +16,8 @@ export class Checkin {
   @CreateDateColumn()
   createdDate: Date;
 
-  @Column({ default: "" })
-  answers: string;
+  @Column("simple-array")
+  answers: string[];
 
   @Column({ default: "" })
   postMessageTs: string;

--- a/api/src/core/migrations/1641349866048-qa-array-of-strings.ts
+++ b/api/src/core/migrations/1641349866048-qa-array-of-strings.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class qaArrayOfStrings1641349866048 implements MigrationInterface {
+  name = "qaArrayOfStrings1641349866048";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`standup\` DROP COLUMN \`questions\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`standup\` ADD \`questions\` text NOT NULL`
+    );
+    await queryRunner.query(`ALTER TABLE \`checkin\` DROP COLUMN \`answers\``);
+    await queryRunner.query(
+      `ALTER TABLE \`checkin\` ADD \`answers\` text NOT NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`checkin\` DROP COLUMN \`answers\``);
+    await queryRunner.query(
+      `ALTER TABLE \`checkin\` ADD \`answers\` varchar(255) NOT NULL DEFAULT ''`
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`standup\` DROP COLUMN \`questions\``
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`standup\` ADD \`questions\` varchar(255) NOT NULL DEFAULT ''`
+    );
+  }
+}

--- a/api/src/standups/dto/create-standup.dto.ts
+++ b/api/src/standups/dto/create-standup.dto.ts
@@ -15,8 +15,8 @@ export class CreateStandupDto {
   @IsNotEmpty()
   channelId: string;
 
-  @IsString()
-  questions: string;
+  @IsString({ each: true })
+  questions: string[];
 
   @IsMilitaryTime()
   startTime: Date;

--- a/api/src/standups/dto/standup.dto.ts
+++ b/api/src/standups/dto/standup.dto.ts
@@ -28,8 +28,8 @@ export class StandupDto {
   channelId: string;
 
   @Expose()
-  @IsString()
-  questions: string;
+  @IsString({ each: true })
+  questions: string[];
 
   @IsArray()
   @Expose()
@@ -39,14 +39,6 @@ export class StandupDto {
   @Expose()
   @IsMilitaryTime()
   startTime: string;
-
-  // @Expose()
-  // @IsArray()
-  // users: {
-  //   id: string;
-  //   image: string;
-  //   name: string;
-  // }[];
 
   @Expose()
   @IsArray()

--- a/api/src/standups/dto/update-standup.dto.ts
+++ b/api/src/standups/dto/update-standup.dto.ts
@@ -17,8 +17,8 @@ export class UpdateStandupDto extends PartialType(CreateStandupDto) {
   name?: string;
 
   @IsOptional()
-  @IsString()
-  questions?: string;
+  @IsString({ each: true })
+  questions?: string[];
 
   @IsMilitaryTime()
   startTime: Date;

--- a/api/src/standups/entities/standup.entity.ts
+++ b/api/src/standups/entities/standup.entity.ts
@@ -14,8 +14,8 @@ export class Standup {
   @Column({ default: "" })
   name: string;
 
-  @Column({ default: "" })
-  questions: string;
+  @Column("simple-array")
+  questions: string[];
 
   @Column("time")
   startTime: Date;

--- a/api/src/standups/standups.controller.ts
+++ b/api/src/standups/standups.controller.ts
@@ -8,13 +8,11 @@ import {
   Delete,
   Query,
   UseFilters,
-  UseGuards,
 } from "@nestjs/common";
 import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { plainToClass } from "class-transformer";
 
 import { EntityNotFoundExceptionFilter } from "../core/filters/entity-not-found-exception.filter";
-import { SlackGuard } from "./../core/guards/slack.guard";
 import { CreateStandupDto } from "./dto/create-standup.dto";
 import { StandupDto } from "./dto/standup.dto";
 import { UpdateStandupDto } from "./dto/update-standup.dto";

--- a/api/src/standups/standups.spec.ts
+++ b/api/src/standups/standups.spec.ts
@@ -43,7 +43,7 @@ describe("StandupController", () => {
       await standupRepository.save({
         name: "test-standup",
         channelId: "channel",
-        questions: "questions",
+        questions: ["questions"],
         days: [],
       });
 
@@ -54,7 +54,7 @@ describe("StandupController", () => {
           {
             name: "test-standup",
             channelId: "channel",
-            questions: "questions",
+            questions: ["questions"],
             days: [],
           },
         ]);
@@ -66,7 +66,7 @@ describe("StandupController", () => {
       await standupRepository.save({
         name: "unique-standup-by-channel",
         channelId: "channelId",
-        questions: "questions",
+        questions: ["questions"],
         days: [],
       });
 
@@ -76,7 +76,7 @@ describe("StandupController", () => {
         .expect({
           channelId: "channelId",
           name: "unique-standup-by-channel",
-          questions: "questions",
+          questions: ["questions"],
           days: [],
         });
     });
@@ -106,14 +106,14 @@ describe("StandupController", () => {
         .send({
           name: "test-standup",
           channelId: "channel",
-          questions: "questions",
+          questions: ["questions"],
           days: ["monday"],
         })
         .expect(201)
         .expect({
           name: "test-standup",
           channelId: "channel",
-          questions: "questions",
+          questions: ["questions"],
           days: ["monday"],
         });
     });
@@ -124,7 +124,7 @@ describe("StandupController", () => {
       await standupRepository.save({
         name: "unique-standup-by-channel",
         channelId: "channelId",
-        questions: "questions",
+        questions: ["questions"],
         days: [],
       });
 
@@ -141,7 +141,7 @@ describe("StandupController", () => {
       await standupRepository.save({
         name: "to-be-deleted",
         channelId: "channelId",
-        questions: "questions",
+        questions: ["questions"],
         days: [],
       });
 

--- a/app/src/components/CheckinCard/index.tsx
+++ b/app/src/components/CheckinCard/index.tsx
@@ -55,7 +55,7 @@ const CheckinCard: FC<Props> = ({ standup, checkin, userInfo }: Props) => (
         </Text>
       </Flex>
 
-      {checkin.answers.split("\n").map((a, i) => (
+      {checkin.answers.map((a, i) => (
         <Flex direction={"row"} w="100%" h="100%" my={2}>
           <Box mr={2} width={"5px"} bgColor={"blue.500"} borderRadius={"xl"} />
 
@@ -64,7 +64,7 @@ const CheckinCard: FC<Props> = ({ standup, checkin, userInfo }: Props) => (
               fontWeight={"bold"}
               color={useColorModeValue("gray.700", "gray.400")}
             >
-              {standup?.questions.split("\n")[i]}
+              {standup?.questions[i]}
             </Text>
             <Text>{a}</Text>
           </Flex>

--- a/app/src/hooks/swr.ts
+++ b/app/src/hooks/swr.ts
@@ -11,7 +11,7 @@ const fetcher = (url: string, token: string) =>
 export interface StandupsResponse {
   name: string;
   channelId: string;
-  questions: string;
+  questions: string[];
   days: string[];
   users: { name: string; id: string; image: string }[];
   startTime: string;
@@ -43,7 +43,7 @@ export const useStandups = () => {
 export interface StandupResponse {
   name: string;
   channelId: string;
-  questions: string;
+  questions: string[];
   days: string[];
   introMessage: string;
   channelName: string;
@@ -71,7 +71,7 @@ export const useStandup = (channelId: string | string[] | undefined) => {
 export interface CheckinResponse {
   id: string;
   createdDate: string;
-  answers: string;
+  answers: string[];
   userId: string;
   channelId: string;
 }

--- a/app/src/pages/profile.tsx
+++ b/app/src/pages/profile.tsx
@@ -64,7 +64,7 @@ const Timeline = () => {
           </Text>
         </Flex>
 
-        {"answer1\nanswer2\nanswer3".split("\n").map((a, i) => (
+        {["answer1", "answer2", "answer3"].map((a, i) => (
           <Flex direction={"row"} w="100%" h="100%" my={2}>
             <Box
               mr={2}
@@ -78,7 +78,7 @@ const Timeline = () => {
                 fontWeight={"bold"}
                 color={useColorModeValue("gray.700", "gray.400")}
               >
-                {"question1\nquestion2\nquestion3".split("\n")[i]}
+                {["answer1", "answer2", "answer3"][i]}
               </Text>
               <Text>{a}</Text>
             </Flex>

--- a/app/src/pages/standups/[channelId]/index.tsx
+++ b/app/src/pages/standups/[channelId]/index.tsx
@@ -92,16 +92,14 @@ const Standup: NextPage = () => {
                 <Skeleton key={index} w="xs" h={4} my={5} />
               ))}
 
-            {standup?.questions
-              ?.split("\n")
-              .map((question: string, index: number) => (
-                <HStack my={3}>
-                  <Circle size="10px" bg={`${colors[index]}.300`} />
-                  <Text fontSize="md" color="gray.500">
-                    {question}
-                  </Text>
-                </HStack>
-              ))}
+            {standup?.questions.map((question: string, index: number) => (
+              <HStack my={3}>
+                <Circle size="10px" bg={`${colors[index]}.300`} />
+                <Text fontSize="md" color="gray.500">
+                  {question}
+                </Text>
+              </HStack>
+            ))}
           </Text>
         </StandupDetailCard>
       </GridItem>
@@ -309,7 +307,7 @@ const Standup: NextPage = () => {
                           </HStack>
                         </Flex>
                         <VStack spacing={2} w="full">
-                          {standup?.questions.split("\n").map((question) => (
+                          {standup?.questions.map((question) => (
                             <Flex
                               w="full"
                               direction={"row"}

--- a/app/src/pages/standups/[channelId]/manage.tsx
+++ b/app/src/pages/standups/[channelId]/manage.tsx
@@ -89,13 +89,13 @@ const Manage: NextPage = () => {
           introMessage: standup?.introMessage || "",
           days: standup?.days || [],
           startTime: standup?.startTime.slice(0, -3) || "",
-          questions: standup?.questions.split("\n") || [],
+          questions: standup?.questions || [],
           active: standup?.active || true,
         }}
         onSubmit={async (values, { setSubmitting }) => {
           const newValues = {
             ...values,
-            questions: values.questions.join("\n"),
+            questions: values.questions,
           };
 
           const response = await fetch(`${API_URL}/standups/${channelId}`, {

--- a/app/src/pages/standups/new.tsx
+++ b/app/src/pages/standups/new.tsx
@@ -66,7 +66,7 @@ const New: NextPage = () => {
         onSubmit={async (values, { setSubmitting }) => {
           const newValues = {
             ...values,
-            questions: values.questions.join("\n"),
+            questions: values.questions,
           };
 
           console.log("POSTOING: ", values);

--- a/bolt/src/blocks/standup.ts
+++ b/bolt/src/blocks/standup.ts
@@ -139,7 +139,7 @@ export const standupBlocks = (
         element: {
           type: "plain_text_input",
           multiline: true,
-          initial_value: standup?.questions || "",
+          initial_value: standup?.questions.join("\n") || "",
           action_id: "questions",
         },
         label: {

--- a/bolt/src/cron.ts
+++ b/bolt/src/cron.ts
@@ -27,7 +27,7 @@ const checkAndPingUsers = async () => {
 
   standups?.forEach(
     async ({ channelId: channel, name, ...standup }: Standup) => {
-      const questions = standup.questions.split("\n").filter((q) => q !== "");
+      const questions = standup.questions.filter((q) => q !== "");
 
       // fetch all users in channel
       const users = await app.client.conversations.members({
@@ -41,7 +41,7 @@ const checkAndPingUsers = async () => {
         // if user already completed/started checkin
         if (checkins.length === 0) {
           // send reminder message & create empty checkin for later completion
-          const checkin = { answers: "", postMessageTs: "", userId: user };
+          const checkin = { answers: [], postMessageTs: "", userId: user };
           await addCheckin(channel, checkin);
 
           await app.client.chat.postMessage({

--- a/bolt/src/models.ts
+++ b/bolt/src/models.ts
@@ -11,7 +11,7 @@ export enum Day {
 export type NewStandup = {
   name: string;
   channelId: string;
-  questions: string;
+  questions: string[];
   days: Day[];
   startTime: string;
   introMessage: string;
@@ -23,12 +23,12 @@ export type Standup = NewStandup & {
 
 export type Checkin = {
   createdDate: Date;
-  answers: string;
+  answers: string[];
   postMessageTs: string;
   id: string;
 };
 
 export type CreateCheckinDTO = {
-  answers: string;
+  answers: string[];
   postMessageTs: string;
 };

--- a/bolt/src/services/api.ts
+++ b/bolt/src/services/api.ts
@@ -47,8 +47,8 @@ export const createCheckin = (
   standup: Standup,
   checkin: Checkin | null
 ): View => {
-  const answers = checkin?.answers?.split("\n") || [];
-  const questions = standup.questions.split("\n");
+  const answers = checkin?.answers || [];
+  const questions = standup.questions;
 
   const blocks = questions.map((question: string, i: number) => ({
     type: "input",

--- a/bolt/src/slack/__tests__/commands.spec.ts
+++ b/bolt/src/slack/__tests__/commands.spec.ts
@@ -40,7 +40,7 @@ describe("The commands handlers", () => {
               id: "id",
               name: "name",
               channelId: "C01LQPT2LMD",
-              questions: "questions",
+              questions: ["questions"],
               days: ["monday"],
             })
           )
@@ -72,7 +72,7 @@ describe("The commands handlers", () => {
               id: "id",
               name: "name",
               channelId: "C01LQPT2LMD",
-              questions: "questions",
+              questions: ["questions"],
               days: ["monday"],
             })
           )
@@ -108,7 +108,7 @@ describe("The commands handlers", () => {
               id: "id",
               name: "name",
               channelId: "C01LQPT2LMD",
-              questions: "questions",
+              questions: ["questions"],
               days: ["monday"],
             })
           )
@@ -119,7 +119,7 @@ describe("The commands handlers", () => {
             res(
               ctx.json({
                 createdDate: new Date(),
-                answers: "answers",
+                answers: ["answers"],
                 postMessageTs: "messageTs",
               })
             )

--- a/bolt/src/slack/__tests__/messages.spec.ts
+++ b/bolt/src/slack/__tests__/messages.spec.ts
@@ -61,7 +61,7 @@ describe("The messages handlers", () => {
               id: "id",
               name: "name",
               channelId: "C01LQPT2LMD",
-              questions: "questions",
+              questions: ["questions"],
               days: ["monday"],
             })
           )
@@ -72,7 +72,7 @@ describe("The messages handlers", () => {
             res(
               ctx.json({
                 createdDate: new Date(),
-                answers: "answers",
+                answers: ["answers"],
                 postMessageTs: "messageTs",
                 channelId: "channelId",
               })
@@ -85,7 +85,7 @@ describe("The messages handlers", () => {
               ctx.json([
                 {
                   createdDate: new Date(),
-                  answers: "answers",
+                  answers: ["answers"],
                   postMessageTs: "messageTs",
                 },
               ])
@@ -116,7 +116,7 @@ describe("The messages handlers", () => {
               id: "id",
               name: "name",
               channelId: "channelId",
-              questions: "question1\nquestion2\nquestion3",
+              questions: ["question1", "question2", "question3"],
               days: ["monday"],
             })
           )
@@ -127,7 +127,7 @@ describe("The messages handlers", () => {
             res(
               ctx.json({
                 createdDate: new Date(),
-                answers: "",
+                answers: [],
                 postMessageTs: "messageTs",
                 channelId: "channelId",
                 id: "id",
@@ -140,7 +140,7 @@ describe("The messages handlers", () => {
             res(
               ctx.json({
                 createdDate: new Date(),
-                answers: "answers",
+                answers: ["answers"],
                 postMessageTs: "messageTs",
               })
             )
@@ -184,7 +184,7 @@ describe("The messages handlers", () => {
               id: "id",
               name: "name",
               channelId: "channelId",
-              questions: "question1\nquestion2\nquestion3",
+              questions: ["question1", "question2", "question3"],
               days: ["monday"],
             })
           )
@@ -195,7 +195,7 @@ describe("The messages handlers", () => {
             res(
               ctx.json({
                 createdDate: new Date(),
-                answers: "answer1\nanswer2",
+                answers: ["answer1", "answer2"],
                 postMessageTs: "messageTs",
                 channelId: "channelId",
                 id: "id",
@@ -208,7 +208,7 @@ describe("The messages handlers", () => {
             res(
               ctx.json({
                 createdDate: new Date(),
-                answers: "answer1\nanswer2\nanswer3",
+                answers: ["answer1", "answer2", "answer3"],
                 postMessageTs: "messageTs",
               })
             )

--- a/bolt/src/slack/__tests__/views.spec.ts
+++ b/bolt/src/slack/__tests__/views.spec.ts
@@ -15,7 +15,7 @@ describe("The views handlers", () => {
               id: "id",
               name: "name",
               channelId: "C01LQPT2LMD",
-              questions: "questions",
+              questions: ["questions"],
               days: ["monday"],
             })
           )
@@ -116,7 +116,7 @@ describe("The views handlers", () => {
               id: "id",
               name: "name",
               channelId: "C01LQPT2LMD",
-              questions: "questions",
+              questions: ["questions"],
               days: ["monday"],
             })
           )
@@ -127,7 +127,7 @@ describe("The views handlers", () => {
             res(
               ctx.json({
                 createdDate: new Date(),
-                answers: "answers",
+                answers: ["answers"],
                 postMessageTs: "messageTs",
               })
             )
@@ -193,7 +193,7 @@ describe("The views handlers", () => {
               id: "id",
               name: "name",
               channelId: "C01LQPT2LMD",
-              questions: "questions",
+              questions: ["questions"],
               days: ["monday"],
             })
           )
@@ -204,7 +204,7 @@ describe("The views handlers", () => {
             res(
               ctx.json({
                 createdDate: new Date(),
-                answers: "answers",
+                answers: ["answers"],
                 postMessageTs: "messageTs",
               })
             )
@@ -217,7 +217,7 @@ describe("The views handlers", () => {
                 {
                   id: "id",
                   createdDate: new Date(),
-                  answers: "answers",
+                  answers: ["answers"],
                   postMessageTs: "messageTs",
                 },
               ])

--- a/bolt/src/slack/messages.ts
+++ b/bolt/src/slack/messages.ts
@@ -28,10 +28,8 @@ export const dmMessage: Middleware<SlackEventMiddlewareArgs<"message">> =
       return;
     }
 
-    const questions = standup.questions.split("\n");
-    const answers = preExistingCheckin.answers
-      .split("\n")
-      .filter((x) => x !== "");
+    const questions = standup.questions;
+    const answers = preExistingCheckin.answers.filter((x) => x !== "");
 
     // @todo if the answers have newlines (i.e. slack bullets)
     // then we exit too early since it counts as another answer
@@ -39,12 +37,12 @@ export const dmMessage: Middleware<SlackEventMiddlewareArgs<"message">> =
       answers.push(text);
 
       const checkin = {
-        answers: answers.join("\n"),
+        answers,
         postMessageTs: ts,
       };
 
       // add checkin
-      const updatedCheckin = await updateCheckin(
+      await updateCheckin(
         preExistingCheckin.channelId,
         checkin,
         preExistingCheckin.id
@@ -77,7 +75,7 @@ export const dmMessage: Middleware<SlackEventMiddlewareArgs<"message">> =
         });
 
         const checkin = {
-          answers: answers.join("\n"),
+          answers,
           postMessageTs: postedMessage.ts,
         };
 

--- a/bolt/src/slack/views.ts
+++ b/bolt/src/slack/views.ts
@@ -37,7 +37,7 @@ export const standupView: Middleware<
   const newStandup: NewStandup = {
     name,
     channelId,
-    questions: String(selectedValues.questions.questions.value),
+    questions: selectedValues.questions.questions.value.split("\n"),
     days: selectedValues.days.days.selected_options.map((d: any) =>
       String(d.value)
     ) as Day[],
@@ -84,7 +84,7 @@ export const checkinView: Middleware<
   const standup = await getStandup(JSON.parse(view.private_metadata).channelId);
 
   // if standup DNE post ephemeral message no standup
-  const questions = standup.questions.split("\n");
+  const questions = standup.questions;
   const answers = Object.keys(selectedValues).map(
     (k) => selectedValues[k][k].value
   );
@@ -117,7 +117,7 @@ export const checkinView: Middleware<
     });
 
     const createCheckinDto = {
-      answers: answers.join("\n"),
+      answers,
       postMessageTs: updateStandupMessage.ts,
       userId: user.user.id,
     };
@@ -143,7 +143,7 @@ export const checkinView: Middleware<
     });
 
     const updateCheckinDto = {
-      answers: answers.join("\n"),
+      answers,
       postMessageTs: standupMessage.ts,
     };
 


### PR DESCRIPTION
## Description

<!-- A summary of changes being introduced -->

This addresses a very silly bug where we store the answers/questions as newline strings **however** that's inherently flawed since users can input checkins with newlines (I do it myself sometimes) which breaks the parsing when we respond to DMs.

If your 1st answer is `something\nsomething else` we interpreted that as two answers which would skip the next question ... which is **no good**.

This updates the ORM def'n + generates a new migration.

## Test Plan

Updated unit tests `answers` `questions` to be string array instead of string.

## Checklist

- [x] Unit tests written/refactored for any new code added/changed
- [x] Test coverage has not been reduced
- [x] Linting requirements met
- [x] CI is passing
