### PR TITLE
Add Quick Action in checkin + optional sections

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,7 @@
     "typeorm:migrate": "npm run typeorm migration:generate -- -n",
     "typeorm:run": "npm run typeorm migration:run",
     "format": "prettier --write \"src/**/*.ts\"",
-    "start": "npm run typeorm:run && TZ=UTC nest start --watch",
+    "start": "TZ=UTC nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/api/src/checkins/checkins.spec.ts
+++ b/api/src/checkins/checkins.spec.ts
@@ -85,6 +85,7 @@ describe("CheckinController", () => {
           expect(body).toEqual([
             {
               id: expect.stringMatching(uuid),
+              outOfOffice: false,
               createdDate: expect.stringMatching(date),
               answers: ["answers"],
               postMessageTs: "postMessageTs",
@@ -128,6 +129,7 @@ describe("CheckinController", () => {
               {
                 answers: ["fooanswer"],
                 channelId: "channelId",
+                outOfOffice: false,
                 id: expect.stringMatching(uuid),
                 createdDate: expect.stringMatching(date),
                 postMessageTs: "postMessageTs",
@@ -136,6 +138,7 @@ describe("CheckinController", () => {
               {
                 answers: ["baranswer"],
                 channelId: "channelId",
+                outOfOffice: false,
                 id: expect.stringMatching(uuid),
                 createdDate: expect.stringMatching(date),
                 postMessageTs: "postMessageTs",
@@ -157,6 +160,7 @@ describe("CheckinController", () => {
         .expect(({ body }) =>
           expect(body).toEqual({
             id: expect.stringMatching(uuid),
+            outOfOffice: false,
             createdDate: expect.stringMatching(date),
             answers: ["answers"],
             postMessageTs: "postMessageTs",
@@ -202,6 +206,7 @@ describe("CheckinController", () => {
         .expect(({ body }) =>
           expect(body).toEqual({
             id: expect.stringMatching(uuid),
+            outOfOffice: false,
             createdDate: expect.stringMatching(date),
             answers: ["answers"],
             postMessageTs: "postMessageTs",
@@ -229,6 +234,7 @@ describe("CheckinController", () => {
           expect(body).toEqual({
             id: expect.stringMatching(uuid),
             createdDate: expect.stringMatching(date),
+            outOfOffice: false,
             answers: ["new-answers"],
             postMessageTs: "post-message-ts",
             userId: "user",

--- a/api/src/checkins/dto/checkin.dto.ts
+++ b/api/src/checkins/dto/checkin.dto.ts
@@ -1,5 +1,5 @@
 import { Exclude, Expose, Transform } from "class-transformer";
-import { IsString, IsDate, IsOptional } from "class-validator";
+import { IsString, IsDate, IsOptional, IsBoolean } from "class-validator";
 
 import { Checkin } from "../entities/checkin.entity";
 
@@ -30,4 +30,8 @@ export class CheckinDto {
   @Expose()
   @Transform(({ obj }: { obj: Checkin }) => obj.standup?.channelId)
   readonly channelId: string;
+
+  @Expose()
+  @IsBoolean()
+  outOfOffice: boolean;
 }

--- a/api/src/checkins/dto/create-checkin.dto.ts
+++ b/api/src/checkins/dto/create-checkin.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from "class-validator";
 
 export class CreateCheckinDto {
   @IsString({ each: true })
@@ -10,4 +10,8 @@ export class CreateCheckinDto {
   @IsString()
   @IsNotEmpty()
   userId: string;
+
+  @IsBoolean()
+  @IsOptional()
+  outOfOffice?: boolean;
 }

--- a/api/src/checkins/dto/update-checkin.dto.ts
+++ b/api/src/checkins/dto/update-checkin.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsBoolean, IsOptional, IsNotEmpty, IsString } from "class-validator";
 
 export class UpdateCheckinDto {
   @IsString({ each: true })
@@ -8,4 +8,8 @@ export class UpdateCheckinDto {
   @IsString()
   @IsNotEmpty()
   postMessageTs: string;
+
+  @IsBoolean()
+  @IsOptional()
+  outOfOffice?: boolean;
 }

--- a/api/src/checkins/entities/checkin.entity.ts
+++ b/api/src/checkins/entities/checkin.entity.ts
@@ -27,6 +27,9 @@ export class Checkin {
   })
   standup: Standup;
 
+  @Column({ default: false })
+  outOfOffice: boolean;
+
   @Column()
   userId: string;
 }

--- a/api/src/core/migrations/1644631574416-outOfOffice.ts
+++ b/api/src/core/migrations/1644631574416-outOfOffice.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class outOfOffice1644631574416 implements MigrationInterface {
+  name = "outOfOffice1644631574416";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`checkin\` ADD \`outOfOffice\` tinyint NOT NULL DEFAULT 0`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`checkin\` DROP COLUMN \`outOfOffice\``
+    );
+  }
+}

--- a/api/src/core/modules/checkin-notifier.module.ts
+++ b/api/src/core/modules/checkin-notifier.module.ts
@@ -31,13 +31,15 @@ export class CheckinNotifierService {
   ): Promise<void> {
     const questions = standup.questions.filter((q) => q !== "");
 
-    // Get user's timezone
-    const timezone = standup.timezoneOverrides.find(
-      (override) => override.userId === userId
-    )?.timezone;
+    // Get user's timezone (or channel if undefined)
+    const timezone =
+      standup.timezoneOverrides.find((override) => override.userId === userId)
+        ?.timezone || standup.timezone;
+
     const offsetDate = this.timeUtils.dateTimezoneOffset(
       this.timeUtils.getTimezoneOffset(timezone)
     );
+
     const dayName = this.timeUtils.getDayName(offsetDate).toLowerCase();
 
     const standupIsToday = standup.days
@@ -50,23 +52,62 @@ export class CheckinNotifierService {
     if (!(standupTimeIsNow && standupIsToday)) return;
 
     // Check if this is the standup day, and it has been past the standup time for their timezone
-
-    const checkins = await this.checkinsService.findAll(standup.channelId, {
-      users: { users: [userId] },
-      // @Todo should we look for standups in our time or their timezone
-      createdDate: new Date().toLocaleDateString(),
-    });
+    const checkins = (
+      await this.checkinsService.findAll(standup.channelId, {
+        users: { users: [userId] },
+        createdDate: offsetDate.toLocaleDateString(),
+      })
+    )
+      // since the standups are stored in UTC we filter out dates that weren't same day as today relative
+      // i.e. if last standup was 9p 2/11 (that's actually 2a 2/12 which is false positive)
+      .filter(
+        (c) =>
+          this.timeUtils
+            .tzOffset(this.timeUtils.getTimezoneOffset(timezone), c.createdDate)
+            .toLocaleDateString() === offsetDate.toLocaleDateString()
+      );
 
     // if user already completed/started checkin
     if (checkins.length === 0) {
       // send reminder message & create empty checkin for later completion
       const checkin = { answers: [], postMessageTs: "", userId: userId };
       await this.checkinsService.create(standup.channelId, checkin);
-      await this.slackService.postMessage(
-        userId,
-        `The *${standup.name}* is about to start.`
-      );
-      await this.slackService.postMessage(userId, questions[0]);
+      await this.slackService.postMessage({
+        channel: userId,
+        text: `The *${standup.name}* is about to start.`,
+      });
+
+      await this.slackService.postMessage({
+        channel: userId,
+        text: questions[0],
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: questions[0],
+            },
+            accessory: {
+              type: "static_select",
+              placeholder: {
+                type: "plain_text",
+                text: "Quick Action",
+                emoji: true,
+              },
+              options: [{ text: "I'm OOO today", value: "ooo" }].map(
+                ({ text, value }) => ({
+                  text: {
+                    type: "plain_text",
+                    text,
+                  },
+                  value,
+                })
+              ),
+              action_id: "checkinMessageDmQuickResponse",
+            },
+          },
+        ],
+      });
     }
   }
 

--- a/api/src/notifications/notifications.spec.ts
+++ b/api/src/notifications/notifications.spec.ts
@@ -171,12 +171,43 @@ describe("NotificationsController", () => {
       expect(postMessage.mock.calls).toMatchInlineSnapshot(`
         Array [
           Array [
-            "id",
-            "The *standup* is about to start.",
+            Object {
+              "channel": "id",
+              "text": "The *standup* is about to start.",
+            },
           ],
           Array [
-            "id",
-            "questions",
+            Object {
+              "blocks": Array [
+                Object {
+                  "accessory": Object {
+                    "action_id": "checkinMessageDmQuickResponse",
+                    "options": Array [
+                      Object {
+                        "text": Object {
+                          "text": "I'm OOO today",
+                          "type": "plain_text",
+                        },
+                        "value": "ooo",
+                      },
+                    ],
+                    "placeholder": Object {
+                      "emoji": true,
+                      "text": "Quick Action",
+                      "type": "plain_text",
+                    },
+                    "type": "static_select",
+                  },
+                  "text": Object {
+                    "text": "questions",
+                    "type": "mrkdwn",
+                  },
+                  "type": "section",
+                },
+              ],
+              "channel": "id",
+              "text": "questions",
+            },
           ],
         ]
       `);
@@ -217,12 +248,43 @@ describe("NotificationsController", () => {
       expect(postMessage.mock.calls).toMatchInlineSnapshot(`
         Array [
           Array [
-            "userId",
-            "The *standup* is about to start.",
+            Object {
+              "channel": "userId",
+              "text": "The *standup* is about to start.",
+            },
           ],
           Array [
-            "userId",
-            "questions",
+            Object {
+              "blocks": Array [
+                Object {
+                  "accessory": Object {
+                    "action_id": "checkinMessageDmQuickResponse",
+                    "options": Array [
+                      Object {
+                        "text": Object {
+                          "text": "I'm OOO today",
+                          "type": "plain_text",
+                        },
+                        "value": "ooo",
+                      },
+                    ],
+                    "placeholder": Object {
+                      "emoji": true,
+                      "text": "Quick Action",
+                      "type": "plain_text",
+                    },
+                    "type": "static_select",
+                  },
+                  "text": Object {
+                    "text": "questions",
+                    "type": "mrkdwn",
+                  },
+                  "type": "section",
+                },
+              ],
+              "channel": "userId",
+              "text": "questions",
+            },
           ],
         ]
       `);
@@ -255,12 +317,43 @@ describe("NotificationsController", () => {
       expect(postMessage.mock.calls).toMatchInlineSnapshot(`
         Array [
           Array [
-            "userId",
-            "The *standup* is about to start.",
+            Object {
+              "channel": "userId",
+              "text": "The *standup* is about to start.",
+            },
           ],
           Array [
-            "userId",
-            "questions",
+            Object {
+              "blocks": Array [
+                Object {
+                  "accessory": Object {
+                    "action_id": "checkinMessageDmQuickResponse",
+                    "options": Array [
+                      Object {
+                        "text": Object {
+                          "text": "I'm OOO today",
+                          "type": "plain_text",
+                        },
+                        "value": "ooo",
+                      },
+                    ],
+                    "placeholder": Object {
+                      "emoji": true,
+                      "text": "Quick Action",
+                      "type": "plain_text",
+                    },
+                    "type": "static_select",
+                  },
+                  "text": Object {
+                    "text": "questions",
+                    "type": "mrkdwn",
+                  },
+                  "type": "section",
+                },
+              ],
+              "channel": "userId",
+              "text": "questions",
+            },
           ],
         ]
       `);

--- a/api/src/slack/slack.service.ts
+++ b/api/src/slack/slack.service.ts
@@ -1,5 +1,9 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { ChatPostMessageResponse, WebClient } from "@slack/web-api";
+import {
+  ChatPostMessageResponse,
+  WebClient,
+  ChatPostMessageArguments,
+} from "@slack/web-api";
 
 import { ChannelDto } from "./dto/channel.dto";
 
@@ -53,9 +57,8 @@ export class SlackService {
   }
 
   async postMessage(
-    channel: string,
-    text: string
+    args: ChatPostMessageArguments
   ): Promise<ChatPostMessageResponse | null> {
-    return this.bolt.chat.postMessage({ channel, text }).catch(() => null);
+    return this.bolt.chat.postMessage({ ...args }).catch(() => null);
   }
 }

--- a/bolt/src/app.ts
+++ b/bolt/src/app.ts
@@ -4,6 +4,7 @@ import cors from "cors";
 import { Request } from "express";
 import _ from "lodash";
 
+import { checkinMessageQuickResponseAction } from "./slack/actions";
 import {
   checkinCommand,
   itotwCommand,
@@ -113,6 +114,7 @@ app.view("checkin", checkinView);
 app.view("standup", standupView);
 app.view("standupUserConfig", standupUserConfigView);
 app.message(/^.*/, dmMessage);
+app.action("checkinMessageDmQuickResponse", checkinMessageQuickResponseAction);
 
 // easter-eggs
 app.command("/random-order", randomOrderCommand);

--- a/bolt/src/blocks/index.ts
+++ b/bolt/src/blocks/index.ts
@@ -8,4 +8,33 @@ export const sectionBlock = (text: string): SectionBlock => ({
   },
 });
 
+export const sectionWithSelect = (
+  label: string,
+  text: string,
+  options: { value: string; text: string }[],
+  actionId: string
+): SectionBlock => ({
+  type: "section",
+  text: {
+    type: "mrkdwn",
+    text,
+  },
+  accessory: {
+    type: "static_select",
+    placeholder: {
+      type: "plain_text",
+      text: label,
+      emoji: true,
+    },
+    options: options.map(({ text, value }) => ({
+      text: {
+        type: "plain_text",
+        text,
+      },
+      value,
+    })),
+    action_id: actionId,
+  },
+});
+
 export * from "./scrumbarista";

--- a/bolt/src/blocks/standup.ts
+++ b/bolt/src/blocks/standup.ts
@@ -21,6 +21,9 @@ export const standupBlocks = (
       value: d.toString(),
     })) || [];
 
+  // API stores seconds (we only need HH:MM)
+  const standupTime = standup?.startTime.slice(0, -3) || "09:00";
+
   return {
     type: "modal",
     callback_id: "standup",
@@ -52,7 +55,7 @@ export const standupBlocks = (
         block_id: "time",
         element: {
           type: "timepicker",
-          initial_time: "09:00",
+          initial_time: standupTime,
           placeholder: {
             type: "plain_text",
             text: "Select time",

--- a/bolt/src/models.ts
+++ b/bolt/src/models.ts
@@ -26,6 +26,7 @@ export type Standup = NewStandup & {
 };
 
 export type Checkin = {
+  outOfOffice: boolean;
   createdDate: Date;
   answers: string[];
   postMessageTs: string;
@@ -35,4 +36,5 @@ export type Checkin = {
 export type CreateCheckinDTO = {
   answers: string[];
   postMessageTs: string;
+  outOfOffice?: boolean;
 };

--- a/bolt/src/services/standup.ts
+++ b/bolt/src/services/standup.ts
@@ -1,0 +1,149 @@
+import { sectionBlock, sectionWithSelect } from "../blocks";
+import { updateCheckin } from "../services/api";
+
+export const onOutOfOffice = async (
+  client,
+  say,
+  user,
+  standup,
+  preExistingCheckin
+) => {
+  // check for checkin with user ID
+  const date = new Date().toLocaleDateString();
+
+  const answers = preExistingCheckin.answers;
+
+  const userInfo = await client.users.info({
+    user,
+    include_locale: true,
+  });
+  // respond with END of checkin & post checkin
+  const postedMessage = await client.chat.postMessage({
+    channel: preExistingCheckin.channelId,
+    attachments: [
+      {
+        color: "#41BC88",
+        blocks: [sectionBlock(`*${standup.name}*\n${date}`)],
+      },
+      {
+        color: "E4E4E4",
+        blocks: [sectionBlock(`*out of office*`)],
+      },
+    ],
+    username: userInfo.user.profile.real_name,
+    icon_url: userInfo.user.profile.image_192,
+  });
+
+  await updateCheckin(
+    preExistingCheckin.channelId,
+    {
+      answers,
+      postMessageTs: postedMessage.ts,
+      outOfOffice: true,
+    },
+    preExistingCheckin.id
+  );
+  say("all done; thanks. We'll see you when you get back!");
+  return;
+};
+
+export const onSkip = async (
+  client,
+  say,
+  user,
+  standup,
+  preExistingCheckin,
+  ts
+) => {
+  // check for next question or end
+
+  const answers = preExistingCheckin.answers;
+  const questions = standup.questions;
+
+  // check for checkin with user ID
+  const date = new Date().toLocaleDateString();
+
+  // add empty answer
+  answers.push("");
+
+  await updateCheckin(
+    preExistingCheckin.channelId,
+    {
+      answers,
+      postMessageTs: ts,
+    },
+    preExistingCheckin.id
+  );
+
+  console.log("SKIP: ", answers);
+
+  // send empty as answer
+  if (answers.length !== questions.length) {
+    // Post message with block to (skip, use last answer, if 1st question I'm OOO today)
+    await client.chat.postMessage({
+      channel: user,
+      blocks: [
+        sectionWithSelect(
+          "Quick Action",
+          questions[answers.length],
+          [
+            { text: "Use previous response", value: "prev" },
+            { text: "I'm OOO today", value: "ooo" },
+            { text: "Skip", value: "skip" },
+          ],
+          "checkinMessageDmQuickResponse"
+        ),
+      ],
+      text: questions[answers.length],
+    });
+  } else {
+    // if answers length == questions length then say standup is done
+    const userInfo = await client.users.info({
+      user,
+      include_locale: true,
+    });
+
+    console.log();
+
+    const postedMessage = await client.chat.postMessage({
+      channel: preExistingCheckin.channelId,
+      attachments: [
+        {
+          color: "#41BC88",
+          blocks: [sectionBlock(`*${standup.name}*\n${date}`)],
+        },
+        ...questions
+          .map((question: string, index: number) => {
+            // if user skipped don't post in channel
+            if (answers[index].length === 0) return;
+
+            return {
+              color: "E4E4E4",
+              blocks: [sectionBlock(`*${question}*\n${answers[index]}`)],
+            };
+          })
+          .filter((x) => {
+            console.log("X IS: ", x);
+            return x !== null && x !== undefined;
+          }),
+      ],
+      username: userInfo.user.profile.real_name,
+      icon_url: userInfo.user.profile.image_192,
+    });
+
+    const checkin = {
+      answers,
+      postMessageTs: postedMessage.ts,
+    };
+
+    // update ts for message here
+    await updateCheckin(
+      preExistingCheckin.channelId,
+      checkin,
+      preExistingCheckin.id
+    );
+
+    say("all done. Thanks!");
+    return;
+  }
+};

--- a/bolt/src/slack/__tests__/commands.spec.ts
+++ b/bolt/src/slack/__tests__/commands.spec.ts
@@ -45,6 +45,7 @@ describe("The commands handlers", () => {
               channelId: "C01LQPT2LMD",
               questions: ["questions"],
               days: ["monday"],
+              startTime: "09:00:00",
             })
           )
         )

--- a/bolt/src/slack/__tests__/messages.spec.ts
+++ b/bolt/src/slack/__tests__/messages.spec.ts
@@ -107,7 +107,7 @@ describe("The messages handlers", () => {
       expect(say.mock.calls[0]).toBeUndefined();
     });
     it("asks next question in current day's standup", async () => {
-      const say = jest.fn();
+      const postMessage = jest.fn();
 
       server.use(
         rest.get("http://localhost:8000/standups/channelId", (req, res, ctx) =>
@@ -118,6 +118,7 @@ describe("The messages handlers", () => {
               channelId: "channelId",
               questions: ["question1", "question2", "question3"],
               days: ["monday"],
+              startTime: "09:00:00",
             })
           )
         ),
@@ -148,7 +149,11 @@ describe("The messages handlers", () => {
       );
 
       await dmMessage({
-        say,
+        client: {
+          chat: {
+            postMessage,
+          },
+        },
         message: {
           channel_type: "im",
           channel: "channel",
@@ -158,9 +163,45 @@ describe("The messages handlers", () => {
         },
       } as any);
 
-      expect(say.mock.calls[0]).toMatchInlineSnapshot(`
+      expect(postMessage.mock.calls[0]).toMatchInlineSnapshot(`
         Array [
-          "question2",
+          Object {
+            "blocks": Array [
+              Object {
+                "accessory": Object {
+                  "action_id": "checkinMessageDmQuickResponse",
+                  "options": Array [
+                    Object {
+                      "text": Object {
+                        "text": "I'm OOO today",
+                        "type": "plain_text",
+                      },
+                      "value": "ooo",
+                    },
+                    Object {
+                      "text": Object {
+                        "text": "Skip",
+                        "type": "plain_text",
+                      },
+                      "value": "skip",
+                    },
+                  ],
+                  "placeholder": Object {
+                    "emoji": true,
+                    "text": "Quick Action",
+                    "type": "plain_text",
+                  },
+                  "type": "static_select",
+                },
+                "text": Object {
+                  "text": "question2",
+                  "type": "mrkdwn",
+                },
+                "type": "section",
+              },
+            ],
+            "channel": "channel",
+          },
         ]
       `);
     });

--- a/bolt/src/slack/actions.ts
+++ b/bolt/src/slack/actions.ts
@@ -1,0 +1,48 @@
+import {
+  Middleware,
+  SlackActionMiddlewareArgs,
+  SlackAction,
+  StaticSelectAction,
+} from "@slack/bolt";
+
+import { getStandup, searchForCheckin } from "../services/api";
+import { onOutOfOffice, onSkip } from "../services/standup";
+
+export const checkinMessageQuickResponseAction: Middleware<
+  SlackActionMiddlewareArgs<SlackAction>
+> = async ({
+  ack,
+  action,
+  body: {
+    user: { id: user },
+  },
+  client,
+  say,
+}) => {
+  await ack();
+
+  // Either `ooo` or `prev` or `skip`
+  const {
+    selected_option: { value },
+    action_ts: ts,
+  } = action as StaticSelectAction;
+
+  // check for checkin with user ID
+  const date = new Date().toLocaleDateString();
+
+  const preExistingCheckin = await searchForCheckin(user, date);
+  const standup = await getStandup(preExistingCheckin?.channelId);
+
+  // cronjob creates partial checkin which we complete here
+  if (!preExistingCheckin) {
+    say("I'm not sure what checkin this is for?");
+    return;
+  }
+
+  switch (value) {
+    case "ooo":
+      return onOutOfOffice(client, say, user, standup, preExistingCheckin);
+    case "skip":
+      return onSkip(client, say, user, standup, preExistingCheckin, ts);
+  }
+};


### PR DESCRIPTION
## Description

The following user stories were from an in-person feature request of a beta user:
1. My @todo items are the same from yesterday, can I easily import yesterdays answers for a question?
2. I don't have anything to add for a given question, can I skip it?

The resulting business logic now exists for checkins:
* The 1st question **Quick Action** is either "I'm OOO today" or "Use previous response"
* All subsequent questions have either "Use previous response" or "Skip"

**Example Prompt**
The dropdown changes based on the question asked.
<img width="809" alt="Screen Shot 2022-02-14 at 8 39 32 PM" src="https://user-images.githubusercontent.com/22754190/153976483-15ca3525-f3ab-4abd-a59f-4498feba27df.png">

**Resulting optional sections**
If a user is OOO:
<img width="429" alt="Screen Shot 2022-02-14 at 8 43 37 PM" src="https://user-images.githubusercontent.com/22754190/153976810-9053f0ad-03e5-4f89-a9ba-eede66168170.png">

If they only answer 1/2 questions ... the non-answered question doesn't appear in the UI (the DB simply stores as empty string for that answer)
<img width="318" alt="Screen Shot 2022-02-14 at 8 43 51 PM" src="https://user-images.githubusercontent.com/22754190/153976830-2bf129a6-f809-4711-b1f7-76ad119c5db4.png">

## Checklist

- [x] Unit tests written/refactored for any new code added/changed
- [x] Test coverage has not been reduced
- [x] Linting requirements met
- [x] CI is passing
